### PR TITLE
Markdown을 html로 랜더링하는 기능 추가

### DIFF
--- a/webapp/blog/templates/blog/post/detail.html
+++ b/webapp/blog/templates/blog/post/detail.html
@@ -1,5 +1,5 @@
 {% extends "blog/base.html" %}
-
+{% load blog_tags %}
 {% block title %}{{ post.title }}{% endblock %}
 
 {% block content %}
@@ -7,7 +7,7 @@
     <p class="date">
         Published {{ post.publish }} by {{ post.author }}
     </p>
-    {{ post.body|linebreaks }}
+    {{ post.body|markdown }}
     <p>
         <a href="{% url "blog:post_share" post.id %}">
             Share this post
@@ -18,7 +18,7 @@
         <p>
             <a href="{{ post.get_absolute_url }}">{{ post.title }}</a>
         </p>
-    {% empty %} 
+    {% empty %}
         <p>There are no similar posts.</p>
     {% endfor %}
     {% with comments.count as total_comments %}

--- a/webapp/blog/templates/blog/post/list.html
+++ b/webapp/blog/templates/blog/post/list.html
@@ -1,5 +1,5 @@
 {% extends "blog/base.html" %}
-
+{% load blog_tags %}
 {% block title %}My Blog{% endblock %}
 
 {% block content %}
@@ -14,10 +14,10 @@
             </a>
         </h2>
         <p class="tags">
-            Tags: 
+            Tags:
             {% for tag in post.tags.all %}
                 <a href="{% url "blog:post_list_by_tag" tag.slug %}">
-                   {{ tag.name }}
+                    {{ tag.name }}
                 </a>
                 {% if not forloop.last %}, {% endif %}
             {% endfor %}
@@ -25,7 +25,7 @@
         <p class="date">
             Published {{ post.publish }} by {{ post.author }}
         </p>
-        {{ post.body|truncatewords:30|linebreaks }}
+        {{ post.body|markdown|truncatewords_html:30 }}
     {% endfor %}
     {% include "pagination.html" with page=posts %}
 {% endblock %}

--- a/webapp/blog/templatetags/blog_tags.py
+++ b/webapp/blog/templatetags/blog_tags.py
@@ -1,5 +1,7 @@
 from django import template
 from django.db.models import Count
+from django.utils.safestring import mark_safe
+from markdown import markdown
 
 from ..models import Post
 
@@ -22,3 +24,9 @@ def get_most_commented_posts(count=5):
     return Post.published.annotate(total_comments=Count("comments")).order_by(
         "-total_comments"
     )[:count]
+
+
+@register.filter(name="markdown")
+def markdown_format(text):
+    # mark_safe: 문자열을 HTML로 렌더링할 때 사용. 이스케이프 처리를 하지않음
+    return mark_safe(markdown(text))

--- a/webapp/blog/tests/test_templatetags.py
+++ b/webapp/blog/tests/test_templatetags.py
@@ -1,11 +1,13 @@
 from django.template import Template, Context
 from django.test import TestCase
+from django.utils.safestring import SafeString
 
 from blog.factory import PostFactory, CommentFactory
 from blog.templatetags.blog_tags import (
     get_most_commented_posts,
     total_posts,
     show_latest_posts,
+    markdown_format,
 )
 
 
@@ -39,3 +41,37 @@ class PostTests(TestCase):
     def test_get_most_commented_posts(self):
         result = get_most_commented_posts(5)
         self.assertEqual(result.count(), 5)
+
+    def test_rendered_markdown_filter(self):
+        markdown_text = (
+            "# Heading\n\nThis is a paragraph "
+            "with *italic* and **bold** text."
+        )
+        expected_html = (
+            "<h1>Heading</h1>\n<p>This is a paragraph "
+            "with <em>italic</em> "
+            "and <strong>bold</strong> text.</p>"
+        )
+
+        template_str = "{% load blog_tags %}{{ markdown_text|markdown }}"
+        template = Template(template_str)
+        context = Context({"markdown_text": markdown_text})
+        rendered_template = template.render(context)
+
+        self.assertIsInstance(rendered_template, SafeString)
+        self.assertEqual(rendered_template, expected_html)
+
+    def test_get_markdown_filter(self):
+        markdown_text = (
+            "# Heading\n\nThis is a paragraph "
+            "with *italic* and **bold** text."
+        )
+        expected_html = (
+            "<h1>Heading</h1>\n<p>This is a paragraph "
+            "with <em>italic</em> "
+            "and <strong>bold</strong> text.</p>"
+        )
+
+        result = markdown_format(markdown_text)
+        self.assertIsInstance(result, SafeString)
+        self.assertEqual(result, expected_html)

--- a/webapp/blog/tests/test_views.py
+++ b/webapp/blog/tests/test_views.py
@@ -13,8 +13,7 @@ from blog.models import Post
 
 class PostListViewTest(TestCase):
     @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
+    def setUpTestData(cls):
         cls.client = Client()
         cls.tags = [TagFactory() for _ in range(randint(1, 3))]
         cls.post_list = PostFactory.create_batch(10)


### PR DESCRIPTION
## 작업 내용

- Markdown -> html 기능 추가

## 관련 이슈

-

## 테스트

- `pytest blog/tests/test_templatetags.py::PostTests`

## 스크린샷 (선택 사항)

